### PR TITLE
Ignore squashfs mounts

### DIFF
--- a/pydf
+++ b/pydf
@@ -495,7 +495,7 @@ def is_special_fs(fs):
     "test if fs (as type) is a special one"
     "in addition, a filesystem is special if it has number of blocks equal to 0"
     fs = fs.lower()
-    return fs in [ "tmpfs", "devpts", "devtmpfs", "proc", "sysfs", "usbfs", "devfs", "fdescfs", "linprocfs" ]
+    return fs in [ "tmpfs", "devpts", "devtmpfs", "proc", "sysfs", "usbfs", "devfs", "fdescfs", "linprocfs", "squashfs" ]
 
 def get_table(mps):
     "table is a list of rows"


### PR DESCRIPTION
These are used by snap packages on Ubuntu and make my `pydf` output look like this:

```
Filesystem         Size  Used Avail  Use%                 Mounted on                    
/dev/nvme0n1p5     284G  265G 4175M  93.5 [############.] /                             
/dev/nvme0n1p1     256M   36M  220M  13.9 [##...........] /boot/efi                     
/home/mg/.Private  284G  265G 4175M  93.5 [############.] /home/mg/Private              
/dev/loop8         104M  104M     0 100.0 [#############] /snap/brackets/112            
/dev/loop6          89M   89M     0 100.0 [#############] /snap/core/7713               
/dev/loop7          89M   89M     0 100.0 [#############] /snap/core/7917               
/dev/loop18         55M   55M     0 100.0 [#############] /snap/core18/1144             
/dev/loop16         55M   55M     0 100.0 [#############] /snap/core18/1192             
/dev/loop3        4864k 4864k     0 100.0 [#############] /snap/faultstat/41            
/dev/loop21       4864k 4864k     0 100.0 [#############] /snap/faultstat/52            
/dev/loop12        150M  150M     0 100.0 [#############] /snap/gnome-3-28-1804/67      
/dev/loop17        150M  150M     0 100.0 [#############] /snap/gnome-3-28-1804/71      
/dev/loop5        4224k 4224k     0 100.0 [#############] /snap/gnome-calculator/406    
/dev/loop10       4352k 4352k     0 100.0 [#############] /snap/gnome-calculator/501    
/dev/loop4          15M   15M     0 100.0 [#############] /snap/gnome-characters/296    
/dev/loop19         15M   15M     0 100.0 [#############] /snap/gnome-characters/317    
/dev/loop13       1024k 1024k     0 100.0 [#############] /snap/gnome-logs/73           
/dev/loop1        1024k 1024k     0 100.0 [#############] /snap/gnome-logs/81           
/dev/loop11       3840k 3840k     0 100.0 [#############] /snap/gnome-system-monitor/100
/dev/loop9        3840k 3840k     0 100.0 [#############] /snap/gnome-system-monitor/95 
/dev/loop14         35M   35M     0 100.0 [#############] /snap/gtk-common-themes/1198  
/dev/loop20         43M   43M     0 100.0 [#############] /snap/gtk-common-themes/1313  
/dev/loop15         11M   11M     0 100.0 [#############] /snap/kubectl/864             
/dev/loop2          55M   55M     0 100.0 [#############] /snap/lxd/11985               
/dev/loop22         55M   55M     0 100.0 [#############] /snap/lxd/12100               
```

They're always readonly, so listing them is pointless: they will always have 0 bytes free.