### PR TITLE
More special fs types (ecryptfs, overlay, efivarfs)

### DIFF
--- a/pydf
+++ b/pydf
@@ -495,7 +495,21 @@ def is_special_fs(fs):
     "test if fs (as type) is a special one"
     "in addition, a filesystem is special if it has number of blocks equal to 0"
     fs = fs.lower()
-    return fs in [ "tmpfs", "devpts", "devtmpfs", "proc", "sysfs", "usbfs", "devfs", "fdescfs", "linprocfs", "squashfs", "ecryptfs", "overlay" ]
+    return fs in [
+        "tmpfs",
+        "devpts",
+        "devtmpfs",
+        "proc",
+        "sysfs",
+        "usbfs",
+        "devfs",
+        "fdescfs",
+        "linprocfs",
+        "squashfs",
+        "ecryptfs",
+        "overlay",
+        "efivarfs",
+    ]
 
 def get_table(mps):
     "table is a list of rows"


### PR DESCRIPTION
None of these things are real filesystems that can run out of space; they just mirror parts of other filesystems that are already displayed by pydf.