### PR TITLE
Make GitHub Actions run simple smoke tests with Python 3.10 and 3.14

### DIFF
--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -1,0 +1,56 @@
+# Copyright (c) 2025 Sebastian Pipping <sebastian@pipping.org>
+# SPDX-License-Identifier: 0BSD
+
+name: Smoke Tests
+
+# Drop permissions to minimum for security
+permissions:
+  contents: read
+
+on:
+  pull_request:
+  push:
+  schedule:
+    - cron: '0 16 * * 5'  # Every Friday 4pm
+  workflow_dispatch:
+
+jobs:
+  smoke-tests:
+    name: Smoke Tests
+
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", 3.14]  # oldest and most recent version supported
+
+    runs-on: ubuntu-24.04
+
+    steps:
+
+    - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
+
+    - uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c  # v6.0.0
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Run smoke tests
+      run: |
+        export PS4=$'\n# '
+        set -x
+        ./pydf
+        ./pydf --help
+        ./pydf --version
+        ./pydf --all
+        ./pydf --human-readable
+        ./pydf --si
+        ./pydf --block-size=1
+        ./pydf --local
+        ./pydf --kilobytes
+        ./pydf --megabytes
+        ./pydf --gigabytes
+        ./pydf --blocks
+        ./pydf --bw
+        ./pydf --scale-bars
+        ./pydf --mounts=/etc/mtab
+        ./pydf --show-binds
+        ./pydf --inodes


### PR DESCRIPTION
Expected behavior and output can be seen at https://github.com/hartwork/pydf-fork/actions?query=branch%3Asimple-github-actions-ci .

@garabik what do you think?
